### PR TITLE
Default token secret

### DIFF
--- a/api/v1alpha1/clickhouse_types.go
+++ b/api/v1alpha1/clickhouse_types.go
@@ -11,7 +11,7 @@ type ClickhouseSpec struct {
 	ServiceCommonSpec `json:",inline"`
 
 	// Authentication reference to Aiven token in a secret
-	AuthSecretRef AuthSecretReference `json:"authSecretRef"`
+	AuthSecretRef AuthSecretReference `json:"authSecretRef,omitempty"`
 
 	// Information regarding secret creation
 	ConnInfoSecretTarget ConnInfoSecretTarget `json:"connInfoSecretTarget,omitempty"`

--- a/api/v1alpha1/clickhouseuser_types.go
+++ b/api/v1alpha1/clickhouseuser_types.go
@@ -25,7 +25,7 @@ type ClickhouseUserSpec struct {
 	ConnInfoSecretTarget ConnInfoSecretTarget `json:"connInfoSecretTarget,omitempty"`
 
 	// Authentication reference to Aiven token in a secret
-	AuthSecretRef AuthSecretReference `json:"authSecretRef"`
+	AuthSecretRef AuthSecretReference `json:"authSecretRef,omitempty"`
 }
 
 // ClickhouseUserStatus defines the observed state of ClickhouseUser

--- a/api/v1alpha1/common.go
+++ b/api/v1alpha1/common.go
@@ -8,7 +8,7 @@ import (
 // AuthSecretReference references a Secret containing an Aiven authentication token
 type AuthSecretReference struct {
 	Name string `json:"name"`
-	Key string `json:"key"`
+	Key  string `json:"key"`
 }
 
 // ConnInfoSecretTarget contains information secret name

--- a/api/v1alpha1/common.go
+++ b/api/v1alpha1/common.go
@@ -7,9 +7,7 @@ import (
 
 // AuthSecretReference references a Secret containing an Aiven authentication token
 type AuthSecretReference struct {
-	// +kubebuilder:validation:MinLength=1
 	Name string `json:"name"`
-	// +kubebuilder:validation:MinLength=1
 	Key string `json:"key"`
 }
 

--- a/api/v1alpha1/connectionpool_types.go
+++ b/api/v1alpha1/connectionpool_types.go
@@ -38,7 +38,7 @@ type ConnectionPoolSpec struct {
 	ConnInfoSecretTarget ConnInfoSecretTarget `json:"connInfoSecretTarget,omitempty"`
 
 	// Authentication reference to Aiven token in a secret
-	AuthSecretRef AuthSecretReference `json:"authSecretRef"`
+	AuthSecretRef AuthSecretReference `json:"authSecretRef,omitempty"`
 }
 
 // ConnectionPoolStatus defines the observed state of ConnectionPool

--- a/api/v1alpha1/database_types.go
+++ b/api/v1alpha1/database_types.go
@@ -31,7 +31,7 @@ type DatabaseSpec struct {
 	TerminationProtection bool `json:"terminationProtection,omitempty"`
 
 	// Authentication reference to Aiven token in a secret
-	AuthSecretRef AuthSecretReference `json:"authSecretRef"`
+	AuthSecretRef AuthSecretReference `json:"authSecretRef,omitempty"`
 }
 
 // DatabaseStatus defines the observed state of Database

--- a/api/v1alpha1/kafka_types.go
+++ b/api/v1alpha1/kafka_types.go
@@ -15,7 +15,7 @@ type KafkaSpec struct {
 	DiskSpace string `json:"disk_space,omitempty"`
 
 	// Authentication reference to Aiven token in a secret
-	AuthSecretRef AuthSecretReference `json:"authSecretRef"`
+	AuthSecretRef AuthSecretReference `json:"authSecretRef,omitempty"`
 
 	// Information regarding secret creation
 	ConnInfoSecretTarget ConnInfoSecretTarget `json:"connInfoSecretTarget,omitempty"`

--- a/api/v1alpha1/kafkaacl_types.go
+++ b/api/v1alpha1/kafkaacl_types.go
@@ -28,7 +28,7 @@ type KafkaACLSpec struct {
 	Username string `json:"username"`
 
 	// Authentication reference to Aiven token in a secret
-	AuthSecretRef AuthSecretReference `json:"authSecretRef"`
+	AuthSecretRef AuthSecretReference `json:"authSecretRef,omitempty"`
 }
 
 // KafkaACLStatus defines the observed state of KafkaACL

--- a/api/v1alpha1/kafkaconnect_types.go
+++ b/api/v1alpha1/kafkaconnect_types.go
@@ -11,7 +11,7 @@ type KafkaConnectSpec struct {
 	ServiceCommonSpec `json:",inline"`
 
 	// Authentication reference to Aiven token in a secret
-	AuthSecretRef AuthSecretReference `json:"authSecretRef"`
+	AuthSecretRef AuthSecretReference `json:"authSecretRef,omitempty"`
 
 	// PostgreSQL specific user configuration options
 	UserConfig KafkaConnectUserConfig `json:"userConfig,omitempty"`

--- a/api/v1alpha1/kafkaconnector_types.go
+++ b/api/v1alpha1/kafkaconnector_types.go
@@ -18,7 +18,7 @@ type KafkaConnectorSpec struct {
 	ServiceName string `json:"serviceName"`
 
 	// Authentication reference to Aiven token in a secret
-	AuthSecretRef AuthSecretReference `json:"authSecretRef"`
+	AuthSecretRef AuthSecretReference `json:"authSecretRef,omitempty"`
 
 	// +kubebuilder:validation:MaxLength=1024
 	// The Java class of the connector.

--- a/api/v1alpha1/kafkaschema_types.go
+++ b/api/v1alpha1/kafkaschema_types.go
@@ -29,7 +29,7 @@ type KafkaSchemaSpec struct {
 	CompatibilityLevel string `json:"compatibilityLevel,omitempty"`
 
 	// Authentication reference to Aiven token in a secret
-	AuthSecretRef AuthSecretReference `json:"authSecretRef"`
+	AuthSecretRef AuthSecretReference `json:"authSecretRef,omitempty"`
 }
 
 // KafkaSchemaStatus defines the observed state of KafkaSchema

--- a/api/v1alpha1/kafkatopic_types.go
+++ b/api/v1alpha1/kafkatopic_types.go
@@ -38,7 +38,7 @@ type KafkaTopicSpec struct {
 	TerminationProtection bool `json:"termination_protection,omitempty"`
 
 	// Authentication reference to Aiven token in a secret
-	AuthSecretRef AuthSecretReference `json:"authSecretRef"`
+	AuthSecretRef AuthSecretReference `json:"authSecretRef,omitempty"`
 }
 
 type KafkaTopicTag struct {

--- a/api/v1alpha1/opensearch_types.go
+++ b/api/v1alpha1/opensearch_types.go
@@ -15,7 +15,7 @@ type OpenSearchSpec struct {
 	DiskSpace string `json:"disk_space,omitempty"`
 
 	// Authentication reference to Aiven token in a secret
-	AuthSecretRef AuthSecretReference `json:"authSecretRef"`
+	AuthSecretRef AuthSecretReference `json:"authSecretRef,omitempty"`
 
 	// Information regarding secret creation
 	ConnInfoSecretTarget ConnInfoSecretTarget `json:"connInfoSecretTarget,omitempty"`

--- a/api/v1alpha1/postgresql_types.go
+++ b/api/v1alpha1/postgresql_types.go
@@ -15,7 +15,7 @@ type PostgreSQLSpec struct {
 	DiskSpace string `json:"disk_space,omitempty"`
 
 	// Authentication reference to Aiven token in a secret
-	AuthSecretRef AuthSecretReference `json:"authSecretRef"`
+	AuthSecretRef AuthSecretReference `json:"authSecretRef,omitempty"`
 
 	// Information regarding secret creation
 	ConnInfoSecretTarget ConnInfoSecretTarget `json:"connInfoSecretTarget,omitempty"`

--- a/api/v1alpha1/project_types.go
+++ b/api/v1alpha1/project_types.go
@@ -58,7 +58,7 @@ type ProjectSpec struct {
 	ConnInfoSecretTarget ConnInfoSecretTarget `json:"connInfoSecretTarget,omitempty"`
 
 	// Authentication reference to Aiven token in a secret
-	AuthSecretRef AuthSecretReference `json:"authSecretRef"`
+	AuthSecretRef AuthSecretReference `json:"authSecretRef,omitempty"`
 }
 
 // ProjectStatus defines the observed state of Project

--- a/api/v1alpha1/projectvpc_types.go
+++ b/api/v1alpha1/projectvpc_types.go
@@ -22,7 +22,7 @@ type ProjectVPCSpec struct {
 	NetworkCidr string `json:"networkCidr"`
 
 	// Authentication reference to Aiven token in a secret
-	AuthSecretRef AuthSecretReference `json:"authSecretRef"`
+	AuthSecretRef AuthSecretReference `json:"authSecretRef,omitempty"`
 }
 
 // ProjectVPCStatus defines the observed state of ProjectVPC

--- a/api/v1alpha1/redis_types.go
+++ b/api/v1alpha1/redis_types.go
@@ -14,7 +14,7 @@ type RedisSpec struct {
 	DiskSpace string `json:"disk_space,omitempty"`
 
 	// Authentication reference to Aiven token in a secret
-	AuthSecretRef AuthSecretReference `json:"authSecretRef"`
+	AuthSecretRef AuthSecretReference `json:"authSecretRef,omitempty"`
 
 	// Information regarding secret creation
 	ConnInfoSecretTarget ConnInfoSecretTarget `json:"connInfoSecretTarget,omitempty"`

--- a/api/v1alpha1/serviceintegration_types.go
+++ b/api/v1alpha1/serviceintegration_types.go
@@ -42,7 +42,7 @@ type ServiceIntegrationSpec struct {
 	MetricsUserConfig ServiceIntegrationMetricsUserConfig `json:"metrics,omitempty"`
 
 	// Authentication reference to Aiven token in a secret
-	AuthSecretRef AuthSecretReference `json:"authSecretRef"`
+	AuthSecretRef AuthSecretReference `json:"authSecretRef,omitempty"`
 }
 
 // ServiceIntegrationStatus defines the observed state of ServiceIntegration

--- a/api/v1alpha1/serviceuser_types.go
+++ b/api/v1alpha1/serviceuser_types.go
@@ -25,7 +25,7 @@ type ServiceUserSpec struct {
 	ConnInfoSecretTarget ConnInfoSecretTarget `json:"connInfoSecretTarget,omitempty"`
 
 	// Authentication reference to Aiven token in a secret
-	AuthSecretRef AuthSecretReference `json:"authSecretRef"`
+	AuthSecretRef AuthSecretReference `json:"authSecretRef,omitempty"`
 }
 
 // ServiceUserStatus defines the observed state of ServiceUser

--- a/config/crd/bases/aiven.io_clickhouses.yaml
+++ b/config/crd/bases/aiven.io_clickhouses.yaml
@@ -40,10 +40,8 @@ spec:
                 description: Authentication reference to Aiven token in a secret
                 properties:
                   key:
-                    minLength: 1
                     type: string
                   name:
-                    minLength: 1
                     type: string
                 required:
                 - key
@@ -126,7 +124,6 @@ spec:
                     type: string
                 type: object
             required:
-            - authSecretRef
             - project
             type: object
           status:

--- a/config/crd/bases/aiven.io_clickhouseusers.yaml
+++ b/config/crd/bases/aiven.io_clickhouseusers.yaml
@@ -50,10 +50,8 @@ spec:
                 description: Authentication reference to Aiven token in a secret
                 properties:
                   key:
-                    minLength: 1
                     type: string
                   name:
-                    minLength: 1
                     type: string
                 required:
                 - key
@@ -84,7 +82,6 @@ spec:
                 maxLength: 63
                 type: string
             required:
-            - authSecretRef
             - project
             - serviceName
             type: object

--- a/config/crd/bases/aiven.io_connectionpools.yaml
+++ b/config/crd/bases/aiven.io_connectionpools.yaml
@@ -59,10 +59,8 @@ spec:
                 description: Authentication reference to Aiven token in a secret
                 properties:
                   key:
-                    minLength: 1
                     type: string
                   name:
-                    minLength: 1
                     type: string
                 required:
                 - key
@@ -106,7 +104,6 @@ spec:
                 maxLength: 64
                 type: string
             required:
-            - authSecretRef
             - databaseName
             - project
             - serviceName

--- a/config/crd/bases/aiven.io_databases.yaml
+++ b/config/crd/bases/aiven.io_databases.yaml
@@ -47,10 +47,8 @@ spec:
                 description: Authentication reference to Aiven token in a secret
                 properties:
                   key:
-                    minLength: 1
                     type: string
                   name:
-                    minLength: 1
                     type: string
                 required:
                 - key
@@ -82,7 +80,6 @@ spec:
                   data.
                 type: boolean
             required:
-            - authSecretRef
             - project
             - serviceName
             type: object

--- a/config/crd/bases/aiven.io_kafkaacls.yaml
+++ b/config/crd/bases/aiven.io_kafkaacls.yaml
@@ -56,10 +56,8 @@ spec:
                 description: Authentication reference to Aiven token in a secret
                 properties:
                   key:
-                    minLength: 1
                     type: string
                   name:
-                    minLength: 1
                     type: string
                 required:
                 - key
@@ -89,7 +87,6 @@ spec:
                 description: Username pattern for the ACL entry
                 type: string
             required:
-            - authSecretRef
             - permission
             - project
             - serviceName

--- a/config/crd/bases/aiven.io_kafkaconnectors.yaml
+++ b/config/crd/bases/aiven.io_kafkaconnectors.yaml
@@ -59,10 +59,8 @@ spec:
                 description: Authentication reference to Aiven token in a secret
                 properties:
                   key:
-                    minLength: 1
                     type: string
                   name:
-                    minLength: 1
                     type: string
                 required:
                 - key
@@ -89,7 +87,6 @@ spec:
                   }}` is provided when interpreting the keys
                 type: object
             required:
-            - authSecretRef
             - connectorClass
             - project
             - serviceName

--- a/config/crd/bases/aiven.io_kafkaconnects.yaml
+++ b/config/crd/bases/aiven.io_kafkaconnects.yaml
@@ -44,10 +44,8 @@ spec:
                 description: Authentication reference to Aiven token in a secret
                 properties:
                   key:
-                    minLength: 1
                     type: string
                   name:
-                    minLength: 1
                     type: string
                 required:
                 - key
@@ -184,7 +182,6 @@ spec:
                     type: integer
                 type: object
             required:
-            - authSecretRef
             - project
             type: object
           status:

--- a/config/crd/bases/aiven.io_kafkas.yaml
+++ b/config/crd/bases/aiven.io_kafkas.yaml
@@ -53,10 +53,8 @@ spec:
                 description: Authentication reference to Aiven token in a secret
                 properties:
                   key:
-                    minLength: 1
                     type: string
                   name:
-                    minLength: 1
                     type: string
                 required:
                 - key
@@ -666,7 +664,6 @@ spec:
                     type: object
                 type: object
             required:
-            - authSecretRef
             - project
             type: object
           status:

--- a/config/crd/bases/aiven.io_kafkaschemas.yaml
+++ b/config/crd/bases/aiven.io_kafkaschemas.yaml
@@ -56,10 +56,8 @@ spec:
                 description: Authentication reference to Aiven token in a secret
                 properties:
                   key:
-                    minLength: 1
                     type: string
                   name:
-                    minLength: 1
                     type: string
                 required:
                 - key
@@ -94,7 +92,6 @@ spec:
                 maxLength: 63
                 type: string
             required:
-            - authSecretRef
             - project
             - schema
             - serviceName

--- a/config/crd/bases/aiven.io_kafkatopics.yaml
+++ b/config/crd/bases/aiven.io_kafkatopics.yaml
@@ -53,10 +53,8 @@ spec:
                 description: Authentication reference to Aiven token in a secret
                 properties:
                   key:
-                    minLength: 1
                     type: string
                   name:
-                    minLength: 1
                     type: string
                 required:
                 - key
@@ -193,7 +191,6 @@ spec:
                   data.
                 type: boolean
             required:
-            - authSecretRef
             - partitions
             - project
             - replication

--- a/config/crd/bases/aiven.io_opensearches.yaml
+++ b/config/crd/bases/aiven.io_opensearches.yaml
@@ -40,10 +40,8 @@ spec:
                 description: Authentication reference to Aiven token in a secret
                 properties:
                   key:
-                    minLength: 1
                     type: string
                   name:
-                    minLength: 1
                     type: string
                 required:
                 - key
@@ -490,7 +488,6 @@ spec:
                     type: boolean
                 type: object
             required:
-            - authSecretRef
             - project
             type: object
           status:

--- a/config/crd/bases/aiven.io_postgresqls.yaml
+++ b/config/crd/bases/aiven.io_postgresqls.yaml
@@ -53,10 +53,8 @@ spec:
                 description: Authentication reference to Aiven token in a secret
                 properties:
                   key:
-                    minLength: 1
                     type: string
                   name:
-                    minLength: 1
                     type: string
                 required:
                 - key
@@ -617,7 +615,6 @@ spec:
                     type: integer
                 type: object
             required:
-            - authSecretRef
             - project
             type: object
           status:

--- a/config/crd/bases/aiven.io_projects.yaml
+++ b/config/crd/bases/aiven.io_projects.yaml
@@ -44,10 +44,8 @@ spec:
                 description: Authentication reference to Aiven token in a secret
                 properties:
                   key:
-                    minLength: 1
                     type: string
                   name:
-                    minLength: 1
                     type: string
                 required:
                 - key
@@ -119,8 +117,6 @@ spec:
                   type: string
                 maxItems: 10
                 type: array
-            required:
-            - authSecretRef
             type: object
           status:
             description: ProjectStatus defines the observed state of Project

--- a/config/crd/bases/aiven.io_projectvpcs.yaml
+++ b/config/crd/bases/aiven.io_projectvpcs.yaml
@@ -53,10 +53,8 @@ spec:
                 description: Authentication reference to Aiven token in a secret
                 properties:
                   key:
-                    minLength: 1
                     type: string
                   name:
-                    minLength: 1
                     type: string
                 required:
                 - key
@@ -76,7 +74,6 @@ spec:
                 maxLength: 63
                 type: string
             required:
-            - authSecretRef
             - cloudName
             - networkCidr
             - project

--- a/config/crd/bases/aiven.io_redis.yaml
+++ b/config/crd/bases/aiven.io_redis.yaml
@@ -40,10 +40,8 @@ spec:
                 description: Authentication reference to Aiven token in a secret
                 properties:
                   key:
-                    minLength: 1
                     type: string
                   name:
-                    minLength: 1
                     type: string
                 required:
                 - key
@@ -292,7 +290,6 @@ spec:
                     type: boolean
                 type: object
             required:
-            - authSecretRef
             - project
             type: object
           status:

--- a/config/crd/bases/aiven.io_serviceintegrations.yaml
+++ b/config/crd/bases/aiven.io_serviceintegrations.yaml
@@ -60,10 +60,8 @@ spec:
                 description: Authentication reference to Aiven token in a secret
                 properties:
                   key:
-                    minLength: 1
                     type: string
                   name:
-                    minLength: 1
                     type: string
                 required:
                 - key
@@ -205,7 +203,6 @@ spec:
                 description: Source service for the integration (if any)
                 type: string
             required:
-            - authSecretRef
             - integrationType
             - project
             type: object

--- a/config/crd/bases/aiven.io_serviceusers.yaml
+++ b/config/crd/bases/aiven.io_serviceusers.yaml
@@ -50,10 +50,8 @@ spec:
                 description: Authentication reference to Aiven token in a secret
                 properties:
                   key:
-                    minLength: 1
                     type: string
                   name:
-                    minLength: 1
                     type: string
                 required:
                 - key
@@ -84,7 +82,6 @@ spec:
                 maxLength: 63
                 type: string
             required:
-            - authSecretRef
             - project
             - serviceName
             type: object

--- a/controllers/controller.go
+++ b/controllers/controller.go
@@ -3,10 +3,10 @@ package controllers
 import (
 	"context"
 	"fmt"
-	"reflect"
-	"strings"
 	"io/ioutil"
 	"os"
+	"reflect"
+	"strings"
 
 	"github.com/go-logr/logr"
 	"github.com/hashicorp/go-multierror"


### PR DESCRIPTION
Allow for an Aiven Token Secret and Key to be set as an ENV on the operator. This removes the requirement for each Custom Resource to pass in an authSecretRef. Though if a custom resource does define one, it will take precedence over the operator level one.

ENVs used:
TOKEN_SECRET - K8s Secret name containing the Aiven Token
TOKEN_SECRET_KEY - Key within k8s secret containing the Aiven Token (defaults to 'token')